### PR TITLE
Fix  Parse error: syntax error, unexpected ')' in /src/vendor/bag2/co…

### DIFF
--- a/src/Emitter/PhpLegacyFunction.php
+++ b/src/Emitter/PhpLegacyFunction.php
@@ -31,7 +31,7 @@ final class PhpLegacyFunction implements Emitter
             $path,
             $options['domain'] ?? '',
             $options['secure'] ?? false,
-            $options['httponly'] ?? false,
+            $options['httponly'] ?? false
         );
     }
 }


### PR DESCRIPTION
…okie/src/Emitter/PhpLegacyFunction.php on line 35

php 7.1の環境でParseエラーが発生しましたので修正致しました。